### PR TITLE
Encoding and dirty metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,13 +9,13 @@
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-update-solr-index</artifactId>
     <name>EASY Update SOLR Index</name>
-    <version>1.x-SNAPSHOT</version>
+    <version>1.0-beta-4</version>
     <properties>
         <main-class>nl.knaw.dans.easy.solr.EasyUpdateSolrIndex</main-class>
     </properties>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.0-beta-4</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,13 +9,13 @@
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-update-solr-index</artifactId>
     <name>EASY Update SOLR Index</name>
-    <version>1.0-beta-4</version>
+    <version>1.x-SNAPSHOT</version>
     <properties>
         <main-class>nl.knaw.dans.easy.solr.EasyUpdateSolrIndex</main-class>
     </properties>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>v1.0-beta-4</tag>
+        <tag>HEAD</tag>
     </scm>
     <dependencies>
         <dependency>

--- a/src/main/scala/nl/knaw/dans/easy/solr/FedoraProviderImpl.scala
+++ b/src/main/scala/nl/knaw/dans/easy/solr/FedoraProviderImpl.scala
@@ -46,7 +46,7 @@ case class FedoraProviderImpl(credentials: FedoraCredentials) extends FedoraProv
       )
     }.get.getEntityInputStream
     try {
-      val s = IOUtils.toString(inputStream)
+      val s = IOUtils.toString(inputStream, "UTF-8")
       if (log.isDebugEnabled) log.debug(s"Retrieved pid=$pid, ds=$dsId:$s")
       s
     } finally {

--- a/src/main/scala/nl/knaw/dans/easy/solr/SolrProviderImpl.scala
+++ b/src/main/scala/nl/knaw/dans/easy/solr/SolrProviderImpl.scala
@@ -24,8 +24,8 @@ import scalaj.http.Http
 case class SolrProviderImpl(solrUrl: URL) extends SolrProvider {
   override def update(doc: String): Try[Unit] = Try {
     val result = Http(solrUrl.toString)
-      .header("Content-Type", "application/xml")
-      .param("commit", "true").postData(doc)
+      .header("Content-Type", "application/xml; charset=utf-8")
+      .param("commit", "true").postData(doc.getBytes("UTF-8"))
       .asString
     if(result.isError) throw new RuntimeException(s"${result.statusLine}, details: ${result.body}")
   }


### PR DESCRIPTION
Fixed two problems:
- The metadata from Fedora was not explicitly interpreted as UTF-8. This caused problems when serializing it to SOLR again. Made both (reading from Fedora, and writing to SOLR) explicit about the encoding.
- Some metadata from Fedora violates rules set in the SOLR schema, specifically some fields (such as "date created") are not allowed to appear more than once. However, in many metadata records they do appear more than once. The legacy EASY code "solves" this by just picking the first one encountered. Solved it here by doing the same, but also logging a warning.
