### PR TITLE
Improved shell script so that a link to it may also start the application

### DIFF
--- a/src/main/assembly/dist/bin/easy-update-solr-index
+++ b/src/main/assembly/dist/bin/easy-update-solr-index
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-BINDIR=`dirname $0`
-HOMEDIR=`dirname $BINDIR`
+BINPATH=`readlink -f $0`
+APPHOME=`dirname \`dirname $BINPATH \``
 
-java -Dlogback.configurationFile=$HOMEDIR/cfg/logback.xml \
-     -Dapp.homedir=$HOMEDIR \
-     -jar $HOMEDIR/bin/easy-update-solr-index.jar $@
+java -Dlogback.configurationFile=$APPHOME/cfg/logback.xml \
+     -Dapp.home=$APPHOME \
+     -jar $APPHOME/bin/easy-update-solr-index.jar $@


### PR DESCRIPTION
By using `readlink` to get the "real path" of the binary first, we make it possible to add the command to the user's `PATH` by linking to the command from `/usr/local/bin`. Advantages:
- No environment variable needed for application home directory
- `PATH` does not need to cotain a lot of separate directories
- Working directory stays unchanged (which would not be the case if using `pushd`, `popd`)
