### PR TITLE
Parent upgrade and remove hardcoded Scallop version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
        <groupId>nl.knaw.dans.shared</groupId>
        <artifactId>dans-scala-prototype</artifactId>
-       <version>1.32</version>
+       <version>1.34</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-update-solr-index</artifactId>
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
-            <version>2.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.yourmediashelf.fedora.client</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
        <groupId>nl.knaw.dans.shared</groupId>
        <artifactId>dans-scala-prototype</artifactId>
-       <version>1.34</version>
+       <version>1.35</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-update-solr-index</artifactId>


### PR DESCRIPTION
fixes [EASY-1049](https://drivenbydata.atlassian.net/browse/EASY-1049)

#### When applied it will
* upgrade the project's parent project to version 1.35
* remove the hardcoded Scallop version 

#### Where should the reviewer @DANS-KNAW/easy start?
`pom.xml`