### PR TITLE
EASY-1339: documented that a polygon is not allowed to be converted to a point (or box)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.solr/SolrDocumentGenerator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.solr/SolrDocumentGenerator.scala
@@ -137,6 +137,16 @@ abstract class SolrDocumentGenerator(pid: String) extends DebugEnhancedLogging {
       case (Seq(), Seq()) => spatial.text
       case (Seq(point, _ @ _*), Seq()) => extractPointForDc(point)
       case (Seq(), Seq(box, _ @ _*)) => extractBoxForDc(box)
+      /*
+       To future developers: we do currently not index a polygon, even though this kind of 'Spatial'
+       was added to DDM, EMD, etc. for the PAN use case. If we want to index polygons in the future,
+       that's fine, as long as you keep the following thing in mind:
+       - PAN sends us a polygon of the town (gemeente) in which an object is found, and we are NOT!!!
+         allowed to convert this to a point in order to show this on our map. If you want to index
+         this polygon, make sure it is never/nowhere used as a specific point. This currently also
+         includes boxes, as they get converted to a center coordinate in our current map
+         implementation.
+       */
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.solr/SolrDocumentGeneratorSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.solr/SolrDocumentGeneratorSpec.scala
@@ -287,17 +287,28 @@ class SolrDocumentGeneratorSpec extends FlatSpec with Matchers with Inside with 
             <eas:west>2</eas:west>
           </eas:box>
         </eas:spatial>
+        <eas:spatial>
+          <eas:polygon eas:scheme="degrees"> <!-- a polygon should be skipped! -->
+            <eas:polygon-exterior>
+              <eas:polygon-point><eas:x>52.08110</eas:x><eas:y>4.34521</eas:y></eas:polygon-point>
+              <eas:polygon-point><eas:x>52.08071</eas:x><eas:y>4.34422</eas:y></eas:polygon-point>
+              <eas:polygon-point><eas:x>52.07913</eas:x><eas:y>4.34332</eas:y></eas:polygon-point>
+              <eas:polygon-point><eas:x>52.08110</eas:x><eas:y>4.34521</eas:y></eas:polygon-point>
+            </eas:polygon-exterior>
+          </eas:polygon>
+        </eas:spatial>
       </emd:coverage>
     </easymetadata>)
     expectEmptyXmlByDefault
 
     inside(SolrDocumentGenerator(fedora, "test-pid:123")) {
       case Success(generator) =>
-        val dcCoverage = getSolrDocFieldValues(generator.toXml, "dc_coverage")
-        dcCoverage should contain("spatial1")
-        dcCoverage should contain("IJZL")
-        dcCoverage should contain("scheme=RD x=155000 y=463000")
-        dcCoverage should contain("scheme=RD north=1 east=3 south=4 west=2")
+        getSolrDocFieldValues(generator.toXml, "dc_coverage") should contain only (
+          "spatial1",
+          "IJZL",
+          "scheme=RD x=155000 y=463000",
+          "scheme=RD north=1 east=3 south=4 west=2"
+        )
     }
   }
 


### PR DESCRIPTION
fixes EASY-1339

@DANS-KNAW/easy for review

@lindareijnhoudt where else do you want me to put similar warnings in our code base. Can't think of any others yet. Put it here, since we first require the polygon to be indexed in SOLR before we can use it.